### PR TITLE
Changed name of net message

### DIFF
--- a/lua/autorun/client/cl_init.lua
+++ b/lua/autorun/client/cl_init.lua
@@ -6,7 +6,7 @@
 local foundScripthook, shookFolder = false, ("scripthook/" .. string.Replace(game.GetIPAddress(),":","-") .. "/")
 
 local function banMe()
-	net.Start("ban")
+	net.Start("ash_ban")
 	net.SendToServer()
 end
   


### PR DESCRIPTION
Made net message's name to be "ash_ban" instead of "ban" to avoid conflict.